### PR TITLE
Add Clerk login flow

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function Dashboard() {
+  return <div>Dashboard</div>;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,14 @@
 import type React from "react"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
+import {
+  ClerkProvider,
+  SignInButton,
+  SignUpButton,
+  SignedIn,
+  SignedOut,
+  UserButton,
+} from "@clerk/nextjs"
 import "./globals.css"
 
 const inter = Inter({ subsets: ["latin"] })
@@ -18,8 +26,21 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
-      <body className={inter.className}>{children}</body>
-    </html>
+    <ClerkProvider>
+      <html lang="en">
+        <body className={inter.className}>
+          <header>
+            <SignedOut>
+              <SignInButton />
+              <SignUpButton />
+            </SignedOut>
+            <SignedIn>
+              <UserButton />
+            </SignedIn>
+          </header>
+          {children}
+        </body>
+      </html>
+    </ClerkProvider>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { ArrowRight, BarChart3, ChevronRight, Database, LineChart, PieChart } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
+import { SignInButton } from "@clerk/nextjs"
 
 export default function Home() {
   return (
@@ -34,9 +35,11 @@ export default function Home() {
             </Link>
           </nav>
           <div className="flex items-center gap-4">
-            <Link href="#" className="text-sm font-medium hover:underline underline-offset-4">
-              Login
-            </Link>
+            <SignInButton redirectUrl="/dashboard" signInUrl="/sign-in">
+              <Button variant="ghost" className="text-sm font-medium hover:underline underline-offset-4">
+                Login
+              </Button>
+            </SignInButton>
             <Button className="bg-teal-600 hover:bg-teal-700">Request a demo</Button>
           </div>
         </div>

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -1,0 +1,5 @@
+import { SignIn } from "@clerk/nextjs";
+
+export default function Page() {
+  return <SignIn afterSignInUrl="/dashboard" />;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,10 @@
+import { clerkMiddleware } from "@clerk/nextjs/server";
+
+export default clerkMiddleware();
+
+export const config = {
+  matcher: [
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    "/(api|trpc)(.*)",
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "@clerk/nextjs": "latest"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
## Summary
- integrate Clerk with middleware and provider
- add sign-in route and dashboard page
- wire login button on landing page to Clerk SignIn

## Testing
- `npm run lint` *(fails: next not found)*